### PR TITLE
also complete if project contains non-alpha numeric characters

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -90,7 +90,7 @@ __gradle-generate-tasks-cache() {
             local task_name="${match[1]}"
             local task_description="${match[3]}"
             # Completion for subproject tasks with ':' prefix
-            if [[ $task_name =~ ^([[:alnum:]:]+):([[:alnum:]]+) ]]; then
+            if [[ $task_name =~ ^([[:alnum:][:punct:]]+):([[:alnum:]]+) ]]; then
                 gradle_all_tasks+="${task_name//:/\\:}:$task_description\n\\:${task_name//:/\\:}:$task_description\n"
                 subproject_tasks+="${match[2]}\n"
             else

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -233,6 +233,13 @@ _gradle() {
     elif [[ ${cur} == -* ]]; then
         __gradle-short-options
     else
+        if [[ ${cur} == :* ]]; then
+            colonStripped=true
+	        cur=`echo "${cur}" | sed 's/^.//'`
+	    else
+	        colonStripped=false
+        fi
+
         __gradle-init-cache-dir
         __gradle-set-project-root-dir
         __gradle-set-build-file
@@ -250,7 +257,11 @@ _gradle() {
                 else
                     cached_tasks=( $(grep "^$cur" $cache_dir/$cached_checksum) )
                 fi
-                COMPREPLY=( $(compgen -W "${cached_tasks[*]}" -- "$cur") )
+                if ${colonStripped} ; then
+                    COMPREPLY=( $(compgen -P ":" -W "${cached_tasks[*]}" -- "$cur") )
+                else
+                    COMPREPLY=( $(compgen -W "${cached_tasks[*]}" -- "$cur") )
+                fi
             else
                 __gradle-notify-tasks-cache-build
             fi

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -175,7 +175,7 @@ __gradle-generate-tasks-cache() {
             task_description="${BASH_REMATCH[3]}"
             gradle_all_tasks+=( "$task_name  - $task_description" )
             # Completion for subproject tasks with ':' prefix
-            if [[ $task_name =~ ^([[:alnum:]:]+):([[:alnum:]]+) ]]; then
+            if [[ $task_name =~ ^([[:alnum:][:punct:]]+):([[:alnum:]]+) ]]; then
                 gradle_all_tasks+=( ":$task_name  - $task_description" )
                 subproject_tasks+=( "${BASH_REMATCH[2]}" )
             else
@@ -233,13 +233,6 @@ _gradle() {
     elif [[ ${cur} == -* ]]; then
         __gradle-short-options
     else
-        if [[ ${cur} == :* ]]; then
-            colonStripped=true
-	        cur=`echo "${cur}" | sed 's/^.//'`
-	    else
-	        colonStripped=false
-        fi
-
         __gradle-init-cache-dir
         __gradle-set-project-root-dir
         __gradle-set-build-file
@@ -257,11 +250,7 @@ _gradle() {
                 else
                     cached_tasks=( $(grep "^$cur" $cache_dir/$cached_checksum) )
                 fi
-                if ${colonStripped} ; then
-                    COMPREPLY=( $(compgen -P ":" -W "${cached_tasks[*]}" -- "$cur") )
-                else
-                    COMPREPLY=( $(compgen -W "${cached_tasks[*]}" -- "$cur") )
-                fi
+                COMPREPLY=( $(compgen -W "${cached_tasks[*]}" -- "$cur") )
             else
                 __gradle-notify-tasks-cache-build
             fi


### PR DESCRIPTION
Currently has a side-effect of not automatically completing until ambiguity if the input starts with a colon.

Preserves old behaviour if the input does not start with a colon.