### PR TITLE
Use actual filename _gradle instead of old gradle-completion.zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here's a demo for the gradle project itself:
 
 ## Installation for Zsh 5.0+
 
-Download and place `gradle-completion.zsh` on your `$fpath`. I recommend `$HOME/.zsh/gradle-completion`:
+Download and place `_gradle` on your `$fpath`. I recommend `$HOME/.zsh/gradle-completion`:
 ```
 git clone git://github.com/eriwen/gradle-completion ~/.zsh/gradle-completion
 ```


### PR DESCRIPTION
The file name of `gradle-completion.zsh` was changed with 6c620749ce61a18b05481820850cfb4b58f40de2 to `_gradle`, but the `README.md` file was not adapted.