### PR TITLE
Complete for gw alias

### DIFF
--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -294,6 +294,6 @@ complete -F _gradle gradle
 complete -F _gradle gradlew
 complete -F _gradle ./gradlew
 
-if hash gw 2>/dev/null; then
+if hash gw 2>/dev/null || alias gw >/dev/null 2>&1; then
     complete -F _gradle gw
 fi


### PR DESCRIPTION
Up to now if a gw executable was found, completion was done for it, but a gw alias was not considered.
Now also an alias called gw causes completion to be done.