### PR TITLE
Complete for BAT files

### DIFF
--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -291,8 +291,11 @@ wrapper              - Generates Gradle wrapper files."
     return 0
 }
 complete -F _gradle gradle
+complete -F _gradle gradle.bat
 complete -F _gradle gradlew
+complete -F _gradle gradlew.bat
 complete -F _gradle ./gradlew
+complete -F _gradle ./gradlew.bat
 
 if hash gw 2>/dev/null; then
     complete -F _gradle gw


### PR DESCRIPTION
When using Gradle from Bash on windows, for example from Cygwin Bash or Git Bash, one could call the BAT file instead of the shellscript, so completion should also work for those.