### PR TITLE
Use gradle repository URL in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here's a demo for the gradle project itself:
 
 Download and place `_gradle` on your `$fpath`. I recommend `$HOME/.zsh/gradle-completion`:
 ```
-git clone git://github.com/eriwen/gradle-completion ~/.zsh/gradle-completion
+git clone git://github.com/gradle/gradle-completion ~/.zsh/gradle-completion
 ```
 
 Add the following do your '.zshrc' file:


### PR DESCRIPTION
The instruction states, that you should clone the repository, but the actual clone command is refering to another repository (probably the source of the gradle-completion project)

Basically this changes the instruction simply to

`git clone git://github.com/eriwen/gradle-completion ~/.zsh/gradle-completion`