### PR TITLE
FIX: error when noclobber is set

### DIFF
--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -1,10 +1,10 @@
 # Bash breaks words on : by default. Subproject tasks have ':'
 # Avoid inaccurate completions for subproject tasks
-COMP_WORDBREAKS=$(echo "$COMP_WORDBREAKS" | sed -e 's/://g')
+COMP_WORDBREAKS=${COMP_WORDBREAKS//:/}
 
 __gradle-set-project-root-dir() {
-    local dir=`pwd`
-    project_root_dir=`pwd`
+    local dir=$(pwd)
+    project_root_dir=$(pwd)
     while [[ $dir != '/' ]]; do
         if [[ -f "$dir/settings.gradle" || -f "$dir/gradlew" ]]; then
             project_root_dir=$dir
@@ -17,7 +17,7 @@ __gradle-set-project-root-dir() {
 
 __gradle-init-cache-dir() {
     cache_dir="$HOME/.gradle/completion"
-    mkdir -p $cache_dir
+    mkdir -p "$cache_dir"
 }
 
 __gradle-set-build-file() {
@@ -33,7 +33,7 @@ __gradle-set-build-file() {
 
 __gradle-set-cache-name() {
     # Cache name is constructed from the absolute path of the build file.
-    cache_name=$(echo $gradle_build_file | sed -e 's/\//_/g')
+    cache_name="${gradle_build_file//\//_}"
 }
 
 __gradle-set-files-checksum() {
@@ -52,10 +52,10 @@ __gradle-generate-script-cache() {
     local cache_ttl_mins=${GRADLE_CACHE_TTL_MINUTES:-30240}
     local script_exclude_pattern=${GRADLE_COMPLETION_EXCLUDE_PATTERN:-"/(build|integTest|out)/"}
 
-    if [[ ! $(find $cache_dir/$cache_name -mmin -$cache_ttl_mins 2>/dev/null) ]]; then
+    if [[ ! $(find "$cache_dir/$cache_name" -mmin -$cache_ttl_mins 2>/dev/null) ]]; then
         # Cache all Gradle scripts
-        local gradle_build_scripts=$(find $project_root_dir -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | egrep -v "$script_exclude_pattern")
-        printf "%s\n" "${gradle_build_scripts[@]}" > $cache_dir/$cache_name
+        local gradle_build_scripts=$(find "$project_root_dir" -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | egrep -v "$script_exclude_pattern")
+        printf "%s\n" "${gradle_build_scripts[@]}" >| "$cache_dir/$cache_name"
     fi
 }
 
@@ -166,16 +166,16 @@ __gradle-generate-tasks-cache() {
     # Reuse Gradle Daemon if IDLE but don't start a new one.
     local gradle_tasks_output
     if [[ ! -z "$($gradle_cmd --status 2>/dev/null | grep IDLE)" ]]; then
-        gradle_tasks_output="$($gradle_cmd -b $gradle_build_file --daemon -q tasks --all)"
+        gradle_tasks_output="$($gradle_cmd -b "$gradle_build_file" --daemon -q tasks --all)"
     else
-        gradle_tasks_output="$($gradle_cmd -b $gradle_build_file --no-daemon -q tasks --all)"
+        gradle_tasks_output="$($gradle_cmd -b "$gradle_build_file" --no-daemon -q tasks --all)"
     fi
     local output_line
     local task_description
     local -a gradle_all_tasks=()
     local -a root_tasks=()
     local -a subproject_tasks=()
-    for output_line in $gradle_tasks_output; do
+    for output_line in "$gradle_tasks_output"; do
         if [[ $output_line =~ ^([[:lower:]][[:alnum:][:punct:]]*)([[:space:]]-[[:space:]]([[:print:]]*))? ]]; then
             task_name="${BASH_REMATCH[1]}"
             task_description="${BASH_REMATCH[3]}"
@@ -199,8 +199,8 @@ __gradle-generate-tasks-cache() {
         done
     fi
 
-    printf "%s\n" "${gradle_all_tasks[@]}" > $cache_dir/$gradle_files_checksum
-    echo $gradle_files_checksum > $cache_dir/$cache_name.md5
+    printf "%s\n" "${gradle_all_tasks[@]}" >| "$cache_dir/$gradle_files_checksum"
+    echo "$gradle_files_checksum" >| "$cache_dir/$cache_name.md5"
 }
 
 __gradle-completion-init() {
@@ -212,7 +212,7 @@ __gradle-completion-init() {
     __gradle-init-cache-dir
     __gradle-set-project-root-dir
     __gradle-set-build-file
-    if [[ -f $gradle_build_file ]]; then
+    if [[ -f "$gradle_build_file" ]]; then
         __gradle-set-cache-name
         __gradle-generate-script-cache
         __gradle-set-files-checksum
@@ -242,19 +242,19 @@ _gradle() {
         __gradle-init-cache-dir
         __gradle-set-project-root-dir
         __gradle-set-build-file
-        if [[ -f $gradle_build_file ]]; then
+        if [[ -f "$gradle_build_file" ]]; then
             __gradle-set-cache-name
             __gradle-generate-script-cache
             __gradle-set-files-checksum
 
             # The cache key is md5 sum of all gradle scripts, so it's valid if it exists.
-            if [[ -f $cache_dir/$cache_name.md5 ]]; then
-                local cached_checksum="$(cat $cache_dir/$cache_name.md5)"
+            if [[ -f "$cache_dir/$cache_name.md5" ]]; then
+                local cached_checksum="$(cat "$cache_dir/$cache_name.md5")"
                 local -a cached_tasks
                 if [[ -z $cur ]]; then
-                    cached_tasks=( $(cat $cache_dir/$cached_checksum) )
+                    cached_tasks=( $(cat "$cache_dir/$cached_checksum") )
                 else
-                    cached_tasks=( $(grep "^$cur" $cache_dir/$cached_checksum) )
+                    cached_tasks=( $(grep "^$cur" "$cache_dir/$cached_checksum") )
                 fi
                 COMPREPLY=( $(compgen -W "${cached_tasks[*]}" -- "$cur") )
             else
@@ -262,7 +262,7 @@ _gradle() {
             fi
 
             # Regenerate tasks cache in the background
-            if [[ $gradle_files_checksum != "$(cat $cache_dir/$cache_name.md5)" || ! -f $cache_dir/$gradle_files_checksum ]]; then
+            if [[ $gradle_files_checksum != "$(cat "$cache_dir/$cache_name.md5")" || ! -f "$cache_dir/$gradle_files_checksum" ]]; then
                 $(__gradle-generate-tasks-cache 1>&2 2>/dev/null &)
             fi
         else


### PR DESCRIPTION
When the `noclobber` option is set, the script fails since it can't
overwrite existing files.
This is fixed by using the `>|` trick to force overwrite.

Also, some double-quoting were added to prevent globbing and word
splitting.