### PR TITLE
Fix arguments of dependencyInsight

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -195,12 +195,12 @@ __gradle_subcommand() {
     case "$words[1]" in
         (dependencies)
             _arguments \
-                '--configuration=[The configuration to generate the report for.]:*:dependency configuration:_gradle_dependency_configurations' && ret=0
+                '--configuration=[The configuration to generate the report for.]:dependency configuration:_gradle_dependency_configurations' && ret=0
             ;;
         (dependencyInsight)
             _arguments \
                 '--dependency=[Shows the details of given dependency.]' \
-                '--configuration=[Looks for the dependency in given configuration.]:*:dependency configuration:_gradle_dependency_configurations' && ret=0
+                '--configuration=[Looks for the dependency in given configuration.]:dependency configuration:_gradle_dependency_configurations' && ret=0
             ;;
         (help)
             _arguments \


### PR DESCRIPTION
--dependency was not being completed after --configuration was used

To reproduce: type
```
gradle dependencyInsight --configuration=compileClasspath --
```
and press "Tab"

Curently: nothing is completed and you see `Completing `dependency configuration' or `corrections'
`
After this commit: `--dependency` is completed