### PR TITLE
Add support for loading as oh-my-zsh plugin

### DIFF
--- a/gradle-completion.plugin.zsh
+++ b/gradle-completion.plugin.zsh
@@ -1,0 +1,3 @@
+compdef _gradle gradle
+compdef _gradle gradlew
+compdef _gradle gw


### PR DESCRIPTION
This would make it easier to load this completion as `oh-my-zsh` plugin. I am by no means an expert at creating oh-my-zsh plugins, so feel free to fork this and update the file to be up to par. As it stands now, I am able to load it as a plugin and it works.

Addresses #13 