### PR TITLE
Halve results - skip completions starting with ':' if nothing is typed

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -158,7 +158,7 @@ __gradle_tasks() {
             local cached_checksum="$(cat $cache_dir/$cache_name.md5)"
             local -a cached_tasks
             if [[ -z $cur ]]; then
-                cached_tasks=(${(f)"$(cat $cache_dir/$cached_checksum)"})
+                cached_tasks=(${(f)"$(grep -v "^\\\:" $cache_dir/$cached_checksum)"})
             else
                 cached_tasks=(${(f)"$(grep "^${cur//:/\\\\:}" $cache_dir/$cached_checksum)"})
             fi

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -196,7 +196,7 @@ __gradle-tasks() {
             local cached_checksum="$(cat "$cache_dir/$cache_name.md5")"
             local -a cached_tasks
             if [[ -z "$cur" ]]; then
-                cached_tasks=( $(cat "$cache_dir/$cached_checksum") )
+                cached_tasks=( $(grep -v "^:" "$cache_dir/$cached_checksum") )
             else
                 cached_tasks=( $(grep "^$cur" "$cache_dir/$cached_checksum") )
             fi


### PR DESCRIPTION
..Otherwise tasks for subprojects are doubled when just
```
./gradlew <tab, tab>
```
e.g.:
```
:some-subproject:someTask
some-subproject:someTask
```

Let's skip those with ":" as there is no value from them.
Ofc if someone types `./gradlew :<tab,tab>` it works as expected.