### PR TITLE
Force `--console plain` for tasks cache generation

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -94,9 +94,9 @@ __gradle-generate-tasks-cache() {
     # Reuse Gradle Daemon if IDLE but don't start a new one.
     local gradle_tasks_output
     if [[ ! -z "$($gradle_cmd --status 2>/dev/null | grep IDLE)" ]]; then
-        gradle_tasks_output="$($gradle_cmd --daemon --build-file $gradle_build_file -q tasks --all 2>/dev/null)"
+        gradle_tasks_output="$($gradle_cmd --daemon --build-file $gradle_build_file --console plain -q tasks --all 2>/dev/null)"
     else
-        gradle_tasks_output="$($gradle_cmd --no-daemon --build-file $gradle_build_file -q tasks --all 2>/dev/null)"
+        gradle_tasks_output="$($gradle_cmd --no-daemon --build-file $gradle_build_file --console plain -q tasks --all 2>/dev/null)"
     fi
     local gradle_all_tasks="" root_tasks="" subproject_tasks="" output_line
     local -a match

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -273,9 +273,9 @@ __gradle-generate-tasks-cache() {
     # Reuse Gradle Daemon if IDLE but don't start a new one.
     local gradle_tasks_output
     if [[ ! -z "$("$gradle_cmd" --status 2>/dev/null | grep IDLE)" ]]; then
-        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --daemon -q tasks --all)"
+        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --daemon --console plain -q tasks --all)"
     else
-        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --no-daemon -q tasks --all)"
+        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --no-daemon --console plain -q tasks --all)"
     fi
     local output_line
     local task_description


### PR DESCRIPTION
Fixes tasks cache generation in case when `org.gradle.console` is explicitly set to `rich` or `verbose`.

See also ohmyzsh/ohmyzsh#8730 and ohmyzsh/ohmyzsh#8731