### PR TITLE
Background cache built should be silent - fix

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -169,7 +169,7 @@ __gradle_tasks() {
 
         # Regenerate tasks cache in the background
         if [[ $gradle_files_checksum != "$(cat $cache_dir/$cache_name.md5)" || ! -f $cache_dir/$gradle_files_checksum || $(wc -c < $cache_dir/$gradle_files_checksum) -le 1 ]]; then
-            $(__gradle-generate-tasks-cache 1>&2 2>/dev/null &)
+            $(__gradle-generate-tasks-cache &> /dev/null &)
         fi
     else
         _describe 'built-in tasks' '(


### PR DESCRIPTION
Signed-off-by: Michał Woś <mw792829570@gmail.com>

In my case it printed gradle task output, even though it was not the first time the cache was built for this project.