### PR TITLE
Use `GRADLE_USER_HOME` for completion cache if set

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -14,7 +14,7 @@ __gradle-set-project-root-dir() {
 }
 
 __gradle-init-cache-dir() {
-    cache_dir="$HOME/.gradle/completion"
+    cache_dir="${GRADLE_USER_HOME:-${HOME}/.gradle}/completion"
     mkdir -p $cache_dir
 }
 


### PR DESCRIPTION
Use the `$GRADLE_USER_HOME` environment variable if set, otherwise use `$HOME/.gradle`