### PR TITLE
Use GRADLE_USER_HOME when available to init cache

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -14,7 +14,7 @@ __gradle-set-project-root-dir() {
 }
 
 __gradle-init-cache-dir() {
-    cache_dir="$HOME/.gradle/completion"
+    cache_dir="${GRADLE_USER_HOME:-$HOME/.gradle}/completion"
     mkdir -p $cache_dir
 }
 


### PR DESCRIPTION
Gradle's home directory's location is configurable by the `GRADLE_USER_HOME` environment variable. This change follows that variable for the completion cache, so users can keep their home directory clean.