### PR TITLE
Update README: Use https protocol for cloning the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ echo $fpath | grep "/usr/local/share/zsh/site-functions"
 
 Download and place the plugin and completion script into your oh-my-zsh plugins directory. 
 ```
-git clone git://github.com/gradle/gradle-completion ~/.oh-my-zsh/plugins/gradle-completion
+git clone https://github.com/gradle/gradle-completion ~/.oh-my-zsh/plugins/gradle-completion
 ```
 
 Add `gradle-completion` to the plugins array in your '.zshrc' file.
@@ -41,7 +41,7 @@ plugins+=(gradle-completion)
 
 Download and place `_gradle` on your `$fpath`. I recommend `$HOME/.zsh/gradle-completion`:
 ```
-git clone git://github.com/gradle/gradle-completion ~/.zsh/gradle-completion
+git clone https://github.com/gradle/gradle-completion ~/.zsh/gradle-completion
 ```
 
 Add the following do your '.zshrc' file:


### PR DESCRIPTION
Thanks for the plugin! Just tried manual installation at Arch and it failed to use git protocol for cloning the repository even though I am authenticated with GitHub and got public keys configured as required. May I suggest replacing `git://` with `https://`? According to what I know, this is what most similar instructions do.

![image](https://user-images.githubusercontent.com/2457146/161437142-a1b514b4-5a2c-4b9a-a571-f9d8d0b105a4.png)

Signed-off as instructed