### PR TITLE
Fix git clone instruction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ echo $fpath | grep "/usr/local/share/zsh/site-functions"
 
 Download and place the plugin and completion script into your oh-my-zsh plugins directory. 
 ```
-git clone git://github.com/gradle/gradle-completion ~/.oh-my-zsh/plugins/gradle-completion
+git clone git@github.com:gradle/gradle-completion.git ~/.oh-my-zsh/plugins/gradle-completion
 ```
 
 Add `gradle-completion` to the plugins array in your '.zshrc' file.


### PR DESCRIPTION
The current instructions fails with:

```
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```