### PR TITLE
Cache completion data under the Gradle user home directory if defined

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -14,7 +14,7 @@ __gradle-set-project-root-dir() {
 }
 
 __gradle-init-cache-dir() {
-    cache_dir="$HOME/.gradle/completion"
+    cache_dir="${GRADLE_USER_HOME:-$HOME/.gradle}/completion"
     mkdir -p $cache_dir
 }
 

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -16,7 +16,7 @@ __gradle-set-project-root-dir() {
 }
 
 __gradle-init-cache-dir() {
-    cache_dir="$HOME/.gradle/completion"
+    cache_dir="${GRADLE_USER_HOME:-$HOME/.gradle}/completion"
     mkdir -p "$cache_dir"
 }
 


### PR DESCRIPTION
Given that Gradle users have the ability to define [GRADLE_USER_HOME](https://docs.gradle.org/8.0/userguide/build_environment.html#sec:gradle_environment_variables), this enhancement attempts to use this environment variable as the base directory for caching completion data.

In case `GRADLE_USER_HOME` is not defined, the default value of `$HOME/.gradle` is used instead, which was the previous behaviour.