### PR TITLE
Replace deprecated egrep with grep -E

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -74,7 +74,7 @@ __gradle-generate-script-cache() {
         zle -R "Generating Gradle build script cache"
         # Cache all Gradle scripts
         local -a gradle_build_scripts
-        gradle_build_scripts=( $(find $project_root_dir -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | egrep -v "$script_exclude_pattern") )
+        gradle_build_scripts=( $(find $project_root_dir -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | grep -E -v "$script_exclude_pattern") )
         printf "%s\n" "${gradle_build_scripts[@]}" >| $cache_dir/$cache_name
     fi
 }

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -70,7 +70,7 @@ __gradle-generate-script-cache() {
 
     if [[ ! $(find "$cache_dir/$cache_name" -mmin "-${cache_ttl_mins}" 2>/dev/null) ]]; then
         # Cache all Gradle scripts
-        local gradle_build_scripts=$(find "$project_root_dir" -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | egrep -v "$script_exclude_pattern")
+        local gradle_build_scripts=$(find "$project_root_dir" -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | grep -E -v "$script_exclude_pattern")
         printf "%s\n" "${gradle_build_scripts[@]}" >| "$cache_dir/$cache_name"
     fi
 }


### PR DESCRIPTION
This commit replaces the use of `egrep` with `grep -E`. 

## Motivation

When this project invokes `egrep` on a machine using GNU grep versions >= 3.8, a warning is printed to the console that `egrep` is obsolescent. This warning is interleaved with the in-progress terminal command, and creates an undesirable user experience. This is reproducible when a build is run (nearly-)immediately after the shell has initialized and the completion cache hasn't been populated. 

**Example output:**
This command intends to run a Gradle task on a subproject in the `worker/` directory in a multi-project repo. When the user presses `Tab` after a few characters, this warning shows up and locks up the terminal for a few seconds.
```shell
❯ ./gradlew -p workegrep: warning: egrep is obsolescent; using ggrep -E
er/erating Gradle build script cache
```

## Additional Background

* Officially, `egrep` and `fgrep` were marked as "not needed" and not part of the official POSIX standard in 2007. 
* Starting with GNU grep 3.8, a warning is printed when `egrep` or `fgrep` invoked.  
* [GNU Grep Release Notes](https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html)

>   The egrep and fgrep commands, which have been deprecated since
>   release 2.5.3 (2007), now warn that they are obsolescent and should
>   be replaced by grep -E and grep -F.