### PR TITLE
Concatenate output of tasks for sub-projects using --all and root project tasks

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -94,9 +94,9 @@ __gradle-generate-tasks-cache() {
     # Reuse Gradle Daemon if IDLE but don't start a new one.
     local gradle_tasks_output
     if [[ ! -z "$($gradle_cmd --status 2>/dev/null | grep IDLE)" ]]; then
-        gradle_tasks_output="$($gradle_cmd --daemon --no-scan --build-file $gradle_build_file --console=plain -q tasks --all 2>/dev/null)"
+        gradle_tasks_output="$($gradle_cmd --daemon --no-scan --build-file $gradle_build_file --console=plain -q tasks --all 2>/dev/null) << $($gradle_cmd --daemon --no-scan --build-file $gradle_build_file --console=plain -q tasks 2>/dev/null)"
     else
-        gradle_tasks_output="$($gradle_cmd --no-daemon --no-scan --build-file $gradle_build_file --console=plain -q tasks --all 2>/dev/null)"
+        gradle_tasks_output="$($gradle_cmd --no-daemon --no-scan --build-file $gradle_build_file --console=plain -q tasks --all 2>/dev/null) << $($gradle_cmd --no-daemon --no-scan --build-file $gradle_build_file --console=plain -q tasks 2>/dev/null)"
     fi
     local gradle_all_tasks="" root_tasks="" subproject_tasks="" output_line
     local -a match

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -279,9 +279,9 @@ __gradle-generate-tasks-cache() {
     # Reuse Gradle Daemon if IDLE but don't start a new one.
     local gradle_tasks_output
     if [[ ! -z "$("$gradle_cmd" --status 2>/dev/null | grep IDLE)" ]]; then
-        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --daemon --no-scan --console=plain -q tasks --all)"
+        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --daemon --no-scan --console=plain -q tasks --all) << $("$gradle_cmd" -b "$gradle_build_file" --daemon --no-scan --console=plain -q tasks)"
     else
-        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --no-daemon --no-scan --console=plain -q tasks --all)"
+        gradle_tasks_output="$("$gradle_cmd" -b "$gradle_build_file" --no-daemon --no-scan --console=plain -q tasks --all) << $("$gradle_cmd" -b "$gradle_build_file" --no-daemon --no-scan --console=plain -q tasks)"
     fi
     local output_line
     local task_description


### PR DESCRIPTION
Turns out `gradle tasks --all` only returns tasks for sub-projects and default tasks for multi-project setup. In order to get autocompletion for root project tasks this has to be concatenated with `gradle tasks` which returns the root project tasks but no sub-project tasks. This is what I see in my repo

```
vvlasov@mac monorepo-demo % gradle --console=plain tasks | grep integration
integrationTest - Runs integration tests.
vvlasov@mac monorepo-demo % gradle --console=plain tasks --all | grep integration
project-1:integrationTest - Runs integration tests.
project-2:integrationTest - Runs integration tests.
project-3:integrationTest - Runs integration tests.
```