### PR TITLE
Support --rerun

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -286,6 +286,7 @@ __gradle_subcommand() {
                 '--recompile-scripts[Force build script recompiling.]' \
                 '--refresh[Refresh the state of resources of the type(s) specified.]:refresh policy:(dependencies)' \
                 '--refresh-dependencies[Refresh the state of dependencies.]' \
+                '--rerun[Causes the particular task to be rerun even if up-to-date.]' \
                 '--rerun-tasks[Ignore previously cached task results.]' \
                 '(--no-scan)--scan[Create a build scan.]' \
                 '(-S --full-stacktrace)'{-s,--stacktrace}'[Print out the stacktrace for all exceptions.]' \

--- a/gradle-completion.bash
+++ b/gradle-completion.bash
@@ -118,6 +118,7 @@ __gradle-long-options() {
 --quiet                 - Log errors only
 --recompile-scripts     - Forces scripts to be recompiled, bypassing caching
 --refresh-dependencies  - Refresh the state of dependencies
+--rerun                 - Causes the particular task to be rerun even if up-to-date.
 --rerun-tasks           - Specifies that any task optimization is ignored
 --scan                  - Create a build scan
 --settings-file         - Specifies the settings file


### PR DESCRIPTION
Gradle now supports a task option `--rerun` that reruns the specific task(s) being run, but not their dependencies.

Useful for tests - `./gradlew test --rerun`.

See https://docs.gradle.org/current/userguide/command_line_interface.html#sec:task_options