### PR TITLE
Fix non-working completion for custom build file

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -34,18 +34,16 @@ __gradle-set-build-file() {
 
     local default_gradle_build_file_name="build.gradle"
     if [[ -r $gradle_settings_file ]]; then
-        default_gradle_build_file_name=${$(grep "^rootProject\.buildFileName" $gradle_settings_file | \
+        local build_file_name=${$(grep "^rootProject\.buildFileName" $gradle_settings_file | \
             sed -n -e "s/rootProject\.buildFileName = [\'\"]\(.*\)[\'\"]/\1/p")}
 
-        default_gradle_build_file_name="${default_gradle_build_file:-build.gradle}"
+        default_gradle_build_file_name="${build_file_name:-build.gradle}"
     fi
 
-    local default_gradle_build_file="$project_root_dir/$default_gradle_build_file_name"
-    if [[ ! -f $default_gradle_build_file ]]; then
-        default_gradle_build_file="$project_root_dir/build.gradle.kts"
+    gradle_build_file="$project_root_dir/$default_gradle_build_file_name"
+    if [[ ! -f $gradle_build_file ]]; then
+        gradle_build_file="$project_root_dir/build.gradle.kts"
     fi
-
-    gradle_build_file=$default_gradle_build_file
 }
 
 __gradle-set-cache-name() {

--- a/_gradle.template
+++ b/_gradle.template
@@ -34,18 +34,16 @@ __gradle-set-build-file() {
 
     local default_gradle_build_file_name="build.gradle"
     if [[ -r $gradle_settings_file ]]; then
-        default_gradle_build_file_name=${$(grep "^rootProject\.buildFileName" $gradle_settings_file | \
+        local build_file_name=${$(grep "^rootProject\.buildFileName" $gradle_settings_file | \
             sed -n -e "s/rootProject\.buildFileName = [\'\"]\(.*\)[\'\"]/\1/p")}
 
-        default_gradle_build_file_name="${default_gradle_build_file:-build.gradle}"
+        default_gradle_build_file_name="${build_file_name:-build.gradle}"
     fi
 
-    local default_gradle_build_file="$project_root_dir/$default_gradle_build_file_name"
-    if [[ ! -f $default_gradle_build_file ]]; then
-        default_gradle_build_file="$project_root_dir/build.gradle.kts"
+    gradle_build_file="$project_root_dir/$default_gradle_build_file_name"
+    if [[ ! -f $gradle_build_file ]]; then
+        gradle_build_file="$project_root_dir/build.gradle.kts"
     fi
-
-    gradle_build_file=$default_gradle_build_file
 }
 
 __gradle-set-cache-name() {


### PR DESCRIPTION
If the root build file has a custom name, the completion of tasks does not work, i.e. it would always fall back to `build.gradle.kts` as the variable `default_gradle_build_file` would never be set.