### PR TITLE
Use `:wrapper` task in wrapper invocations as it's only relevant on the root project

### DIFF
--- a/.github/workflows/generate_completions.yml
+++ b/.github/workflows/generate_completions.yml
@@ -39,10 +39,10 @@ jobs:
           echo "Selected Gradle version: $GRADLE_VERSION"
 
       - name: Upgrade Gradle Wrapper - Stage 1
-        run: ./gradlew wrapper --gradle-version=${{ steps.gradle-version.outputs.gradle-version }}
+        run: ./gradlew :wrapper --gradle-version=${{ steps.gradle-version.outputs.gradle-version }}
 
       - name: Upgrade Gradle Wrapper - Stage 2
-        run: ./gradlew wrapper
+        run: ./gradlew :wrapper
 
       - name: Generate Scripts
         run: ./gradlew generateCompletionScripts


### PR DESCRIPTION
Wherever we recommend invoking the `wrapper` task, we should use `:wrapper` to make it explicit that only the root project needs to be configured. This matters for Configure on Demand and may play a role with Isolated Projects in the future.

Related:
- gradle/gradle#37761
- gradle/gradle-private#5228